### PR TITLE
Fixed Issue (ValueError: SCREENS should contain a Screen type or callable, not an instance (got instance of Main for 'main'))

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
-
+Venv
 .DS_Store
+.gitignore

--- a/testapp.py
+++ b/testapp.py
@@ -298,9 +298,9 @@ class TestScreen(Screen):
 class TestApp(App):
 
     SCREENS = {
-        "main": Main(),
-        "test": TestScreen(),
-        "menu": MenuScreen(),
+        "main": Main,
+        "test": TestScreen,
+        "menu": MenuScreen,
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
The error mentioned in #1 occurs because the App class expects SCREENS to contain class types or callables that return screen instances, not instances of Screen themselves. Hence just passed the callables in the SCREEN dictionary.

However there is a new error, as in this picture. I am still trying to explore why this might be occurring.

![image](https://github.com/user-attachments/assets/107aa1d6-c7f7-41ce-93c8-f580a651a2b0)
